### PR TITLE
Bump the downloaded DuckDB to 1.5.3

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -54,7 +54,7 @@ meta->around_hook(
 # Configure for share (i.e., when building from source or downloading prebuilt binaries)
 share {
     # Current DuckDB version to use
-    my $duckdb_version = '1.2.2';
+    my $duckdb_version = '1.5.3';
     
     # Determine platform and architecture
     my $os = $^O;


### PR DESCRIPTION
The `share` block pins `$duckdb_version = '1.2.2'` (alienfile:57), which is the version downloaded from the duckdb/duckdb releases. DuckDB is at **1.5.3** now.

This PR changes that one line. We have been running exactly this patch locally for a while to build [DBD::DuckDB](https://metacpan.org/pod/DBD::DuckDB) against a current libduckdb, and it works unchanged — the release asset naming is the same.

### Two things I did *not* change, but that you may want to look at

**1. The CPAN release and this branch disagree about the version.** `PERIGRIN/Alien-DuckDB-0.03.tar.gz` on CPAN carries a different alienfile than `main` — the released one has `my $version = '1.3.0'` and no PkgConfig plugin, this branch has `$duckdb_version = '1.2.2'` and the newer PkgConfig/`gather_system` structure. So 0.03 was cut from a different line than what is on `main`, and `main` currently pins an *older* DuckDB than the released tarball does. Worth reconciling before the next release, otherwise a bump here may not be what ships.

**2. The system fallback guesses a version.** In `gather_system`, when `pkg-config --modversion libduckdb` yields nothing, `runtime_prop->{version}` falls back to the literal `'1.2.2'` (alienfile:20). That is a guess about a library the user already had installed, so bumping it along with the download version would just be a different guess — I left it alone deliberately. If a consumer ever needs to make a decision based on that value, an undef (or a hard failure) would be more honest than a number that may be wrong. Mentioning it because it is the same literal and easy to "fix" in the wrong direction.

### Why this matters to us

Consumers that build against the C API get whatever this file pins. `DBD::DuckDB` currently ships an FFI binding that assumes a reasonably current libduckdb, and our test suite for the DuckDB driver only passes against 1.5.x — on the 1.3.0 that the current CPAN release pulls, one of our type tests fails. So today the published `Alien::DuckDB` and the published `DBD::DuckDB` are a version apart in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gjTNxGvhtptnxHCNnpvaP